### PR TITLE
Add genre  preloader in animeServices/fillAnimeModel

### DIFF
--- a/api/src/services/animeServices.js
+++ b/api/src/services/animeServices.js
@@ -1,8 +1,10 @@
 const utils = require('../utils/utils');
 const { Anime, Genre } = require('../db.js');
 const { Op } = require('sequelize');
-
+const genreServices = require('./genresServices');
 exports.fillAnimeModel = async () => {
+  
+  await genreServices.fillGenreModel();
 
   let options = {
     include: [{


### PR DESCRIPTION
- Se añade el preloader o servicio de fillGenreModel dentro del propio servicio de fillAnimeModel. Esto con el motivo de que la primera ruta cargada se la de géneros. Así, animes puede añadir la relaciona únicamente si ya se cargaron los géneros en la base de datos.